### PR TITLE
For RISC-V64 OHOS toolchain，Fix the hilog dependency to compile ets_frontend and stub

### DIFF
--- a/arkcompiler/ets_frontend/es2panda/util/helpers.cpp
+++ b/arkcompiler/ets_frontend/es2panda/util/helpers.cpp
@@ -630,10 +630,11 @@ SignedNumberLiteral Helpers::GetSignedNumberLiteral(const ir::Expression *expr)
 
 void Helpers::OptimizeProgram(panda::pandasm::Program *prog,  const std::string &inputFile)
 {
+    // The possibility of handling variables that may not be used
     std::map<std::string, size_t> stat;
-    std::map<std::string, size_t> *statp = &stat;
+    [[maybe_unused]] std::map<std::string, size_t> *statp = &stat;
     panda::pandasm::AsmEmitter::PandaFileToPandaAsmMaps maps{};
-    panda::pandasm::AsmEmitter::PandaFileToPandaAsmMaps *mapsp = &maps;
+    [[maybe_unused]] panda::pandasm::AsmEmitter::PandaFileToPandaAsmMaps *mapsp = &maps;
 
 #ifdef PANDA_WITH_BYTECODE_OPTIMIZER
     const uint32_t COMPONENT_MASK = panda::Logger::Component::ASSEMBLER |

--- a/arkcompiler/ets_frontend/merge_abc/BUILD.gn
+++ b/arkcompiler/ets_frontend/merge_abc/BUILD.gn
@@ -142,6 +142,7 @@ config("proto_file_cpp_config") {
 ohos_source_set("assembly_proto_static") {
   cflags = [ "-Wno-error=zero-length-array" ]
 
+  # Cause Proto -> hilog:libhilog
   deps = [
     ":arkcompiler_generate_proto",
     "$ark_third_party_root/protobuf:protobuf_lite_static",

--- a/arkcompiler/toolchain/build/core/gn/BUILD.gn
+++ b/arkcompiler/toolchain/build/core/gn/BUILD.gn
@@ -53,7 +53,7 @@ group("ets_runtime") {
   ]
   # Maybe we need append `riscv-ohos` architecture in the future
   if ((target_os == "linux" && target_cpu == "x64") ||
-      (target_cpu == "arm64" && target_os == "ohos") {
+      (target_cpu == "arm64" && target_os == "ohos")) {
       # (target_cpu == "riscv64" && target_os == "ohos")) {
     deps += [
       "$js_root/ecmascript/compiler:ark_aot_compiler",

--- a/arkcompiler/toolchain/build/core/gn/BUILD.gn
+++ b/arkcompiler/toolchain/build/core/gn/BUILD.gn
@@ -53,7 +53,8 @@ group("ets_runtime") {
   ]
   # Maybe we need append `riscv-ohos` architecture in the future
   if ((target_os == "linux" && target_cpu == "x64") ||
-      (target_cpu == "arm64" && target_os == "ohos")) {
+      (target_cpu == "arm64" && target_os == "ohos") {
+      # (target_cpu == "riscv64" && target_os == "ohos")) {
     deps += [
       "$js_root/ecmascript/compiler:ark_aot_compiler",
       "$js_root/ecmascript/compiler:ark_stub_compiler",

--- a/arkcompiler/toolchain/build/core/gn/BUILD.gn
+++ b/arkcompiler/toolchain/build/core/gn/BUILD.gn
@@ -51,6 +51,7 @@ group("ets_runtime") {
     "$js_root/ecmascript/js_vm:ark_js_vm",
     "$js_root/ecmascript/quick_fix:quick_fix",
   ]
+  # Maybe we need append `riscv-ohos` architecture in the future
   if ((target_os == "linux" && target_cpu == "x64") ||
       (target_cpu == "arm64" && target_os == "ohos")) {
     deps += [
@@ -62,7 +63,10 @@ group("ets_runtime") {
 }
 
 group("ets_frontend") {
-  if ((target_os == "linux" && target_cpu == "x64") || target_os == "mingw") {
+  # FIX: Add the ohos-riscv64 ets_frontend dependency
+  if ((target_os == "linux" && target_cpu == "x64") || 
+      (target_os == "mingw") || 
+      (target_os == "ohos" && target_cpu == "riscv64")) {
     deps = [
       "$ets_frontend_root/es2panda:es2panda",
       "$ets_frontend_root/merge_abc:merge_abc",

--- a/arkcompiler/toolchain/build/third_party_gn/protobuf/BUILD.gn
+++ b/arkcompiler/toolchain/build/third_party_gn/protobuf/BUILD.gn
@@ -12,6 +12,9 @@
 # limitations under the License.
 
 import("//developtools/profiler/build/config.gni")
+
+# To Append the `enable_hilog` identifier
+import("//arkcompiler/runtime_core/ark_config.gni")
 import("$build_root/ark.gni")
 
 THIRDPARTY_PROTOBUF_SUBSYS_NAME = "thirdparty"
@@ -60,9 +63,10 @@ ohos_shared_library("protobuf_lite") {
     "$protobuf_src_root/google/protobuf/**/*.inc",
     "$protobuf_src_root",
   ]
+  # Cause the hiloh:libhilog
   if (!is_mingw) {
     if (current_toolchain != host_toolchain) {
-      external_deps = [ "hilog:libhilog" ]
+      # external_deps = [ "hilog:libhilog" ]
     }
   } else {
     defines = [ "_FILE_OFFSET_BITS_SET_LSEEK" ]
@@ -117,7 +121,9 @@ ohos_static_library("protobuf_lite_static") {
     "$protobuf_src_root",
   ]
   if (!is_mingw) {
-    if (current_toolchain != host_toolchain) {
+    # Here Cause Error, can't deal with dependency: "hilog:libhilog"
+    # Fix: use enable_hilog
+    if (enable_hilog && current_toolchain != host_toolchain) {
       # target build, not host build
       defines = [ "HAVE_HILOG" ]
       external_deps = [ "hilog:libhilog" ]

--- a/arkcompiler/toolchain/build/third_party_gn/protobuf/BUILD.gn
+++ b/arkcompiler/toolchain/build/third_party_gn/protobuf/BUILD.gn
@@ -65,8 +65,8 @@ ohos_shared_library("protobuf_lite") {
   ]
   # Cause the hiloh:libhilog
   if (!is_mingw) {
-    if (current_toolchain != host_toolchain) {
-      # external_deps = [ "hilog:libhilog" ]
+    if (enable_hilog && current_toolchain != host_toolchain) {
+      external_deps = [ "hilog:libhilog" ]
     }
   } else {
     defines = [ "_FILE_OFFSET_BITS_SET_LSEEK" ]


### PR DESCRIPTION
Mainly for `riscv64-ohos` architecture for dependency judgment processing, to solve the direct use `!is_mingw` thus leads to `hilog` dependence on problems that cannot be solved. 

Use the `enable_hilog` command to fix the problem.